### PR TITLE
distinguish Other type in AlarmObject

### DIFF
--- a/src/alarmobject.cpp
+++ b/src/alarmobject.cpp
@@ -196,14 +196,14 @@
 
 AlarmObject::AlarmObject(QObject *parent)
     : QObject(parent), m_hour(0), m_minute(0), m_second(0), m_enabled(false),
-      m_createdDate(QDateTime::currentDateTime()), m_countdown(false), m_reminder(false), m_triggerTime(0),
+      m_createdDate(QDateTime::currentDateTime()), m_countdown(false), m_reminder(false), m_event(false), m_triggerTime(0),
       m_elapsed(0), m_cookie(0), m_timeoutSnoozeCounter(0), m_maximalTimeoutSnoozeCount(0)
 {
 }
 
 AlarmObject::AlarmObject(const QMap<QString,QString> &data, QObject *parent)
     : QObject(parent), m_hour(0), m_minute(0), m_second(0), m_enabled(false),
-      m_createdDate(QDateTime::currentDateTime()), m_countdown(false), m_reminder(false), m_triggerTime(0),
+      m_createdDate(QDateTime::currentDateTime()), m_countdown(false), m_reminder(false), m_event(false), m_triggerTime(0),
       m_elapsed(0), m_cookie(0)
 {
     for (QMap<QString,QString>::ConstIterator it = data.begin(); it != data.end(); it++) {
@@ -256,6 +256,8 @@ AlarmObject::AlarmObject(const QMap<QString,QString> &data, QObject *parent)
             m_phoneNumber = it.value();
         } else if (it.key() == QLatin1String("type") && it.value() == QLatin1String("reminder")) {
             m_reminder = true;
+        } else if (it.key() == QLatin1String("type") && it.value() == QLatin1String("event")) {
+            m_event = true;
         }
     }
 
@@ -359,12 +361,14 @@ int AlarmObject::type() const
 {
     if (m_reminder)
         return Reminder;
+    else if (m_event)
+        return Clock;
     else if (m_startDate.isValid() && m_endDate.isValid())
         return Calendar;
     else if (m_countdown)
         return Countdown;
     else
-        return Clock;
+        return Other;
 }
 
 /*!

--- a/src/alarmobject.h
+++ b/src/alarmobject.h
@@ -70,7 +70,7 @@ public:
     AlarmObject(QObject *parent = 0);
     AlarmObject(const QMap<QString,QString> &data, QObject *parent = 0);
 
-    enum Type { Calendar, Clock, Countdown, Reminder };
+    enum Type { Calendar, Clock, Countdown, Reminder, Other };
     Q_ENUMS(Type)
 
     QString title() const { return m_title; }
@@ -157,6 +157,7 @@ protected:
     QDateTime m_createdDate;
     bool m_countdown;
     bool m_reminder;
+    bool m_event;
     uint m_triggerTime;
     uint m_elapsed;
     QDateTime m_startDate, m_endDate;


### PR DESCRIPTION
I have some Type=wakeup cookies in timed. I would like to distinguish when showing alarm
```
jmlich@manajro-virt:~/workspace/nemo-qml-plugin-alarms/src (master =)$ timedclient-qt5 -i
Cookie 213
  APPLICATION = 'nemoalarms'
  TITLE = 'Alarm'
  createdDate = '1654001594719'
  daysOfWeek = 'mtwTfsS'
  timeOfDayWithSeconds = '53640'
  type = 'clock'
  Tick: 0 (inactive)
  Time: 0000-00-00 00:00 
Cookie 218
  APPLICATION = 'wakup_alarm'
  type = 'wakeup'
  Tick: 0 (inactive)
  Time: 0000-00-00 00:00 
```